### PR TITLE
Fix README test path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This repo is meant to be a starting point for writing Aztec contracts and tests on the Aztec sandbox (local development environment).
 
-You can find the **Easy Private Voting contract** in `./src/main.nr`. A simple integration test is in `./src/test/index.test.ts`.
+You can find the **Easy Private Voting contract** in `./src/main.nr`. A simple integration test is in `./src/test/e2e/index.test.ts`.
 
 The corresponding tutorial can be found in the [Aztec docs here](https://docs.aztec.network/developers/tutorials/codealong/contract_tutorials/private_voting_contract).
 
@@ -121,7 +121,7 @@ Then test with:
 yarn test
 ```
 
-Testing will run the **TypeScript tests** defined in `index.test.ts` inside `./src/test`, as well as the [Aztec Testing eXecution Environment (TXE)](https://docs.aztec.network/developers/guides/smart_contracts/testing) tests defined in [`first.nr`](./src/test/first.nr) (imported in the contract file with `mod test;`).
+Testing will run the **TypeScript tests** defined in `e2e/index.test.ts` inside `./src/test`, as well as the [Aztec Testing eXecution Environment (TXE)](https://docs.aztec.network/developers/guides/smart_contracts/testing) tests defined in [`first.nr`](./src/test/first.nr) (imported in the contract file with `mod test;`).
 
 Note: The Typescript tests spawn an instance of the sandbox to test against, and close it once the TS tests are complete.
 


### PR DESCRIPTION
## Summary
- update README to point to the real test file location

## Testing
- `yarn test` *(fails: Error when performing the request to https://registry.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_684179e9c2f08327b44da0814486c80b