### PR TITLE
Fix sponsered variable names

### DIFF
--- a/scripts/fees.ts
+++ b/scripts/fees.ts
@@ -62,9 +62,9 @@ async function main() {
     logger.info(`Fee Juice minted to ${feeJuiceRecipient} on L2.`)
 
     // set up sponsored fee payments
-    const sponseredFPC = await getSponsoredFPCInstance();
-    await pxe.registerContract({ instance: sponseredFPC, artifact: SponsoredFPCContract.artifact });
-    const paymentMethod = new SponsoredFeePaymentMethod(sponseredFPC.address);
+    const sponsoredFPC = await getSponsoredFPCInstance();
+    await pxe.registerContract({ instance: sponsoredFPC, artifact: SponsoredFPCContract.artifact });
+    const paymentMethod = new SponsoredFeePaymentMethod(sponsoredFPC.address);
 
     // Two arbitrary txs to make the L1 message available on L2
     const votingContract = await EasyPrivateVotingContract.deploy(wallet1, wallet1.getAddress()).send({ fee: { paymentMethod } }).deployed();
@@ -120,8 +120,8 @@ async function main() {
     // Sponsored Fee Payment
 
     // This method will only work in environments where there is a sponsored fee contract deployed 
-    const deployedSponseredFPC = await getDeployedSponsoredFPCAddress(pxe);
-    const sponsoredPaymentMethod = new SponsoredFeePaymentMethod(deployedSponseredFPC);
+    const deployedSponsoredFPC = await getDeployedSponsoredFPCAddress(pxe);
+    const sponsoredPaymentMethod = new SponsoredFeePaymentMethod(deployedSponsoredFPC);
     await bananaCoin.withWallet(wallet2).methods.transfer_in_private(wallet2.getAddress(), wallet1.getAddress(), 10, 0).send({ fee: { paymentMethod: sponsoredPaymentMethod } }).wait()
     logger.info(`Transfer paid with fees from Sponsored FPC.`)
 }

--- a/scripts/multiple_pxe.ts
+++ b/scripts/multiple_pxe.ts
@@ -58,10 +58,10 @@ async function main() {
 
     const pxe1 = await setupPxe1();
     const pxe2 = await setupPxe2();
-    const sponseredFPC = await getSponsoredFPCInstance();
-    await pxe1.registerContract({ instance: sponseredFPC, artifact: SponsoredFPCContract.artifact });
-    await pxe2.registerContract({ instance: sponseredFPC, artifact: SponsoredFPCContract.artifact });
-    const paymentMethod = new SponsoredFeePaymentMethod(sponseredFPC.address);
+    const sponsoredFPC = await getSponsoredFPCInstance();
+    await pxe1.registerContract({ instance: sponsoredFPC, artifact: SponsoredFPCContract.artifact });
+    await pxe2.registerContract({ instance: sponsoredFPC, artifact: SponsoredFPCContract.artifact });
+    const paymentMethod = new SponsoredFeePaymentMethod(sponsoredFPC.address);
     // deploy token contract
 
     let secretKey = Fr.random();


### PR DESCRIPTION
## Summary
- fix variable names `sponseredFPC`/`deployedSponseredFPC`

## Testing
- `yarn test:js` *(fails: Error: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68417b0b466083278e1e445ca39b97c5