### PR TITLE
Fix awaited sender registration

### DIFF
--- a/scripts/multiple_pxe.ts
+++ b/scripts/multiple_pxe.ts
@@ -74,7 +74,7 @@ async function main() {
 
     // setup account on 2nd pxe
 
-    pxe2.registerSender(ownerAddress)
+    await pxe2.registerSender(ownerAddress)
 
     let secretKey2 = Fr.random();
     let salt2 = Fr.random();
@@ -83,7 +83,7 @@ async function main() {
     // deploy account on 2nd pxe
     let tx2 = await schnorrAccount2.deploy({ fee: { paymentMethod } }).wait();
     let wallet2 = await schnorrAccount2.getWallet();
-    wallet2.registerSender(ownerAddress)
+    await wallet2.registerSender(ownerAddress)
 
     // mint to account on 2nd pxe
 


### PR DESCRIPTION
## Summary
- await `pxe2.registerSender` and `wallet2.registerSender` in `multiple_pxe.ts`

## Testing
- `npx tsc -p . --noEmit` *(fails: cannot find modules)*
- `yarn test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68417b156380832780e68eacbc6be579