### PR TITLE
Enhance account deployment test

### DIFF
--- a/src/test/e2e/accounts.test.ts
+++ b/src/test/e2e/accounts.test.ts
@@ -122,7 +122,18 @@ describe("Accounts", () => {
     });
 
     it("Deploys first unfunded account from first funded account", async () => {
-        const tx_acc = await randomAccountManagers[0].deploy({ fee: { paymentMethod: sponsoredPaymentMethod }, deployWallet: ownerWallet }).wait();
+        const receipt = await randomAccountManagers[0]
+            .deploy({ fee: { paymentMethod: sponsoredPaymentMethod }, deployWallet: ownerWallet })
+            .wait();
+
+        expect(receipt).toEqual(
+            expect.objectContaining({
+                status: TxStatus.SUCCESS,
+            }),
+        );
+
+        const deployedWallet = await randomAccountManagers[0].getWallet();
+        expect(deployedWallet.getAddress()).toEqual(randomAccountManagers[0].getAddress());
     });
 
     it("Sponsored contract deployment", async () => {


### PR DESCRIPTION
## Summary
- verify the transaction receipt after deploying an unfunded account
- check the deployed wallet address matches the account manager address

## Testing
- `yarn test:js` *(fails: Error when performing the request ...)*

------
https://chatgpt.com/codex/tasks/task_e_68417b359c708327b4aac182bfe33650