### PR TITLE
Remove unused imports

### DIFF
--- a/.github/scripts/update-readme-version.js
+++ b/.github/scripts/update-readme-version.js
@@ -1,6 +1,4 @@
 import { readFileSync, writeFileSync } from 'fs';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
 
 // Read Nargo.toml
 const nargoContent = readFileSync('Nargo.toml', 'utf8');
@@ -24,4 +22,4 @@ const updatedContent = readmeContent.replace(
 
 // Write back to README
 writeFileSync(readmePath, updatedContent);
-console.log(`Updated README.md with version ${version}`); 
+console.log(`Updated README.md with version ${version}`);


### PR DESCRIPTION
## Summary
- remove unused `dirname` and `fileURLToPath` imports
- ensure script ends with a newline

## Testing
- `yarn test:js` *(fails: Error when performing the request to https://registry.yarnpkg.com)*

------
https://chatgpt.com/codex/tasks/task_e_68417ba55e8c8327a241c35f88e9c926