### PR TITLE
Update nightly workflow to sync test version

### DIFF
--- a/.github/workflows/nightly-update.yaml
+++ b/.github/workflows/nightly-update.yaml
@@ -47,11 +47,17 @@ jobs:
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: |
           tag=${{ steps.latest.outputs.latest }}
+          echo "TAG=$tag" >> $GITHUB_ENV
           aztec-up -v ${tag#v}
 
       - name: Run yarn update
         if: steps.latest.outputs.latest != steps.current.outputs.current
         run: yarn update
+
+      - name: Update tests workflow version
+        if: steps.latest.outputs.latest != steps.current.outputs.current
+        run: |
+          sed -i "s/VERSION=[0-9.]*/VERSION=${TAG#v}/" .github/workflows/tests.yaml
 
       - name: Clean up temporary files
         if: steps.latest.outputs.latest != steps.current.outputs.current


### PR DESCRIPTION
## Summary
- export nightly version tag to re-use across steps
- update tests workflow with the nightly version

## Testing
- `yarn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0d48ed88327908eadd94002a862